### PR TITLE
Improve static routes and AI-readable Markdown content

### DIFF
--- a/tanstack/public/robots.txt
+++ b/tanstack/public/robots.txt
@@ -7,6 +7,3 @@ Disallow: /*?filter=
 Disallow: /*.pdf$
 
 Sitemap: https://saybackend.com/sitemap-index.xml
-
-# Crawl-delay for non-Google bots
-Crawl-delay: 10

--- a/tanstack/scripts/finalize-static-build.mjs
+++ b/tanstack/scripts/finalize-static-build.mjs
@@ -8,6 +8,7 @@ await copyFile(notFoundSource, notFoundTarget)
 
 const requiredArtifacts = [
   '404.html',
+  'llms.txt',
   'rss.xml',
   'sitemap-index.xml',
   'sitemap-0.xml',

--- a/tanstack/scripts/verify-routes.mjs
+++ b/tanstack/scripts/verify-routes.mjs
@@ -53,6 +53,12 @@ const sitemapPaths = Array.from(
 const pagePaths = [
   ...new Set([...sitemapPaths, '/tags/', '/hiring/', '/pagefind']),
 ]
+const markdownPaths = sitemapPaths
+  .filter(
+    (path) =>
+      /^\/blog\/[^/]+\/$/.test(path) || /^\/projects\/[^/]+\/$/.test(path),
+  )
+  .map((path) => `${path.slice(0, -1)}.md`)
 const failures = []
 
 for (const path of pagePaths) {
@@ -61,6 +67,18 @@ for (const path of pagePaths) {
   const expectedCanonical = canonicalFor(path)
   const actualCanonical = attribute(html, 'link', 'href', 'rel', 'canonical')
   const isArticle = path.startsWith('/blog/') && path !== '/blog/'
+  const publishedTime = isArticle
+    ? attribute(html, 'meta', 'content', 'property', 'article:published_time')
+    : undefined
+  const modifiedTime = isArticle
+    ? attribute(html, 'meta', 'content', 'property', 'article:modified_time')
+    : undefined
+  const hasMarkdownDocument =
+    (path.startsWith('/blog/') && path !== '/blog/') ||
+    (path.startsWith('/projects/') && path !== '/projects/')
+  const markdownAlternate = hasMarkdownDocument
+    ? `${productionOrigin}${path.replace(/\/$/, '')}.md`
+    : undefined
 
   if (
     response.status !== 200 ||
@@ -70,9 +88,14 @@ for (const path of pagePaths) {
     !html.includes('property="og:title"') ||
     !html.includes('name="twitter:card"') ||
     actualCanonical !== expectedCanonical ||
+    (hasMarkdownDocument &&
+      !html.includes(
+        `rel="alternate" type="text/markdown" href="${markdownAlternate}"`,
+      )) ||
     (isArticle &&
       (!html.includes('property="og:type" content="article"') ||
-        !html.includes('property="article:published_time"') ||
+        !publishedTime?.match(/T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$/) ||
+        !modifiedTime?.match(/T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$/) ||
         !html.includes('"@type":"BlogPosting"')))
   ) {
     failures.push({
@@ -82,6 +105,50 @@ for (const path of pagePaths) {
       actualCanonical,
     })
   }
+}
+
+for (const path of markdownPaths) {
+  const response = await fetch(new URL(path, baseUrl))
+  const source = await response.text()
+  const canonicalPath = `${path.slice(0, -3)}/`
+  const canonical = canonicalFor(canonicalPath)
+  const link = response.headers.get('link')
+
+  if (
+    response.status !== 200 ||
+    !response.headers.get('content-type')?.startsWith('text/markdown') ||
+    response.headers.get('x-robots-tag') !== 'noindex, follow' ||
+    link !== `<${canonical}>; rel="canonical"; type="text/html"` ||
+    !source.startsWith('---') ||
+    /^import\s+.+from\s+['"]@?\//m.test(source) ||
+    /^<[A-Z][A-Za-z0-9]*\b/m.test(source) ||
+    /^\s*\/>\s*$/m.test(source)
+  ) {
+    failures.push({
+      path,
+      status: response.status,
+      contentType: response.headers.get('content-type'),
+      link,
+    })
+  }
+}
+
+const missingMarkdownResponse = await fetch(
+  `${baseUrl}/blog/not-a-real-article.md`,
+)
+if (missingMarkdownResponse.status !== 404) {
+  failures.push({
+    path: '/blog/not-a-real-article.md',
+    status: missingMarkdownResponse.status,
+  })
+}
+
+const singleUseTagResponse = await fetch(`${baseUrl}/tags/backend`)
+if (singleUseTagResponse.status !== 404) {
+  failures.push({
+    path: '/tags/backend',
+    status: singleUseTagResponse.status,
+  })
 }
 
 const homeResponse = await fetch(baseUrl)
@@ -120,6 +187,7 @@ for (const [from, expectedPath] of Object.entries(legacyRedirects)) {
 
 for (const endpoint of [
   '/rss.xml',
+  '/llms.txt',
   '/sitemap-index.xml',
   '/sitemap-0.xml',
   '/robots.txt',
@@ -135,6 +203,7 @@ if (failures.length > 0) {
   process.exitCode = 1
 } else {
   console.log(
-    `Verified ${pagePaths.length} content pages, ${Object.keys(legacyRedirects).length} legacy redirects, and 4 feed/discovery endpoints.`,
+    `Verified ${pagePaths.length} content pages, ${Object.keys(legacyRedirects).length} legacy redirects, and 5 feed/discovery endpoints.`,
+    `Verified ${markdownPaths.length} Markdown documents.`,
   )
 }

--- a/tanstack/src/components/SiteShell.tsx
+++ b/tanstack/src/components/SiteShell.tsx
@@ -142,6 +142,7 @@ function SiteFooter() {
         <span>© {new Date().getFullYear()} SayBackend</span>
         <div>
           <a href="/rss.xml">RSS</a>
+          <a href="/llms.txt">LLMs</a>
           <a href="/sitemap-index.xml">Sitemap</a>
           <a href="mailto:hello@kamran.sh">Email</a>
         </div>

--- a/tanstack/src/lib/content.tsx
+++ b/tanstack/src/lib/content.tsx
@@ -151,6 +151,22 @@ export function getProject(slug: string) {
   return projects.find((project) => project.slug === slug)
 }
 
+const tagCounts = new Map<string, number>()
+const MIN_NAVIGABLE_TAG_COUNT = 2
+posts.forEach((post) =>
+  post.tags?.forEach((tag) =>
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1),
+  ),
+)
+
+export const navigableTags = [...tagCounts.entries()]
+  .filter(([, count]) => count >= MIN_NAVIGABLE_TAG_COUNT)
+  .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+
+export function isNavigableTag(tag: string) {
+  return (tagCounts.get(tag) ?? 0) >= MIN_NAVIGABLE_TAG_COUNT
+}
+
 export function getRelatedPosts(post: Post, limit = 3) {
   const tags = new Set(post.tags ?? [])
   return posts

--- a/tanstack/src/lib/markdown.server.ts
+++ b/tanstack/src/lib/markdown.server.ts
@@ -1,0 +1,225 @@
+import '@tanstack/react-start/server-only'
+
+import { getPost, getProject } from '@/lib/content'
+import { SITE } from '@/lib/site'
+
+const blogSources = {
+  ...import.meta.glob<string>('../content/blog/07-*/index.mdx', {
+    eager: true,
+    import: 'default',
+    query: '?content-source-only',
+  }),
+  ...import.meta.glob<string>('../content/blog/10-*/index.mdx', {
+    eager: true,
+    import: 'default',
+    query: '?content-source-only',
+  }),
+  ...import.meta.glob<string>('../content/blog/20*/index.mdx', {
+    eager: true,
+    import: 'default',
+    query: '?content-source-only',
+  }),
+}
+
+const projectSources = import.meta.glob<string>(
+  '../content/projects/**/index.md',
+  {
+    eager: true,
+    import: 'default',
+    query: '?content-source-only',
+  },
+)
+
+function directoryId(path: string) {
+  return path.split('/').at(-2) ?? path
+}
+
+function sourcesById(sources: Record<string, string>) {
+  return new Map(
+    Object.entries(sources).map(([path, source]) => [
+      directoryId(path),
+      source,
+    ]),
+  )
+}
+
+const blogSourcesById = sourcesById(blogSources)
+const projectSourcesById = sourcesById(projectSources)
+
+type MarkdownDocument = {
+  canonicalPath: string
+  filename: string
+  source: string
+}
+
+function stripMdxImports(source: string) {
+  const lines = source.split('\n')
+  const frontmatterEnd = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === '---',
+  )
+  if (frontmatterEnd === -1) return source
+
+  let index = frontmatterEnd + 1
+  while (index < lines.length) {
+    if (!lines[index].trim()) {
+      index += 1
+      continue
+    }
+    if (!lines[index].trimStart().startsWith('import ')) break
+
+    do {
+      index += 1
+    } while (index < lines.length && !lines[index - 1].trimEnd().endsWith(';'))
+  }
+
+  return [
+    ...lines.slice(0, frontmatterEnd + 1),
+    '',
+    ...lines.slice(index),
+  ].join('\n')
+}
+
+function humanizeComponent(name: string) {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase()
+}
+
+function componentFallback(block: string, canonical: string) {
+  const name = block.match(/^<([A-Za-z][A-Za-z0-9]*)/)?.[1] ?? 'Component'
+  const alt = block
+    .match(/\balt=(?:"([^"]*)"|'([^']*)')/)
+    ?.slice(1)
+    .find(Boolean)
+  const title = block
+    .match(/\btitle=(?:"([^"]*)"|'([^']*)')/)
+    ?.slice(1)
+    .find(Boolean)
+  const directUrl = block
+    .match(/\b(?:href|url|repo)=(?:"([^"]*)"|'([^']*)')/)
+    ?.slice(1)
+    .find(Boolean)
+
+  if (name === 'Picture' || name === 'img') {
+    const src = block
+      .match(/\bsrc=(?:"([^"]*)"|'([^']*)')/)
+      ?.slice(1)
+      .find(Boolean)
+    const label = alt || title || 'Article image'
+    if (src) {
+      return `![${label}](${new URL(src, SITE.origin).href})`
+    }
+    return `[Image: ${label}](${canonical})`
+  }
+
+  const label = title || humanizeComponent(name)
+  if (directUrl) return `[${label}](${directUrl})`
+  return `[Interactive element: ${label}](${canonical})`
+}
+
+function toPortableMarkdown(source: string, canonicalPath: string) {
+  const canonical = new URL(canonicalPath, SITE.origin).href
+  const lines = stripMdxImports(source).split('\n')
+  const output: string[] = []
+  let inFence = false
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence
+      output.push(line)
+      continue
+    }
+    if (inFence) {
+      output.push(line)
+      continue
+    }
+
+    const trimmed = line.trim()
+    if (/^<\/[A-Z][A-Za-z0-9]*>$/.test(trimmed)) continue
+    if (/^<Callout\b/.test(trimmed)) {
+      const block = [line]
+      while (
+        !block.at(-1)?.trimEnd().endsWith('>') &&
+        index + 1 < lines.length
+      ) {
+        block.push(lines[(index += 1)])
+      }
+      const markup = block.join(' ')
+      const title = markup
+        .match(/\btitle=(?:"([^"]*)"|'([^']*)')/)
+        ?.slice(1)
+        .find(Boolean)
+      const type = markup.match(/\btype=(?:"([^"]*)"|'([^']*)')/)?.[1]
+      output.push(`**${title || (type === 'warning' ? 'Warning' : 'Note')}:**`)
+      continue
+    }
+    if (/^<(?:img\b|[A-Z][A-Za-z0-9]*\b)/.test(trimmed)) {
+      const block = [line]
+      while (
+        !block.at(-1)?.trimEnd().endsWith('>') &&
+        index + 1 < lines.length
+      ) {
+        block.push(lines[(index += 1)])
+      }
+      output.push(componentFallback(block.join(' '), canonical))
+      continue
+    }
+
+    output.push(line)
+  }
+
+  return output
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+export function getBlogMarkdown(slug: string): MarkdownDocument | undefined {
+  const post = getPost(slug)
+  const source = post ? blogSourcesById.get(post.id) : undefined
+  if (!post || !source) return
+
+  const canonicalPath = `${post.href}/`
+  return {
+    canonicalPath,
+    filename: `${post.slug}.md`,
+    source: toPortableMarkdown(source, canonicalPath),
+  }
+}
+
+export function getProjectMarkdown(slug: string): MarkdownDocument | undefined {
+  const project = getProject(slug)
+  const source = project ? projectSourcesById.get(project.id) : undefined
+  if (!project || !source) return
+
+  const canonicalPath = `${project.href}/`
+  return {
+    canonicalPath,
+    filename: `${project.slug}.md`,
+    source: toPortableMarkdown(source, canonicalPath),
+  }
+}
+
+export function markdownResponse(document: MarkdownDocument | undefined) {
+  if (!document) {
+    return new Response('Markdown document not found.\n', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+  }
+
+  const canonical = new URL(document.canonicalPath, SITE.origin).href
+  return new Response(
+    document.source.endsWith('\n') ? document.source : `${document.source}\n`,
+    {
+      headers: {
+        'Cache-Control':
+          'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800',
+        'Content-Disposition': `inline; filename="${document.filename}"`,
+        'Content-Language': 'en',
+        'Content-Type': 'text/markdown; charset=utf-8',
+        Link: `<${canonical}>; rel="canonical"; type="text/html"`,
+        'X-Robots-Tag': 'noindex, follow',
+      },
+    },
+  )
+}

--- a/tanstack/src/lib/site.ts
+++ b/tanstack/src/lib/site.ts
@@ -44,6 +44,7 @@ type SeoInput = {
   title: string
   description: string
   path: string
+  markdownPath?: string
   image?: string
   type?: 'website' | 'article'
   noindex?: boolean
@@ -57,6 +58,7 @@ export function seo({
   title,
   description,
   path,
+  markdownPath,
   image = '/images/blog.png',
   type = 'website',
   noindex = false,
@@ -74,6 +76,12 @@ export function seo({
   const robots = noindex
     ? 'noindex,follow'
     : 'index,follow,max-image-preview:large'
+  const publishedDateTime = publishedTime
+    ? toIsoDateTime(publishedTime)
+    : undefined
+  const modifiedDateTime = modifiedTime
+    ? toIsoDateTime(modifiedTime)
+    : undefined
 
   return {
     meta: [
@@ -94,19 +102,19 @@ export function seo({
       ...(type === 'article'
         ? [
             { name: 'author', content: 'Kamran Tahir' },
-            ...(publishedTime
+            ...(publishedDateTime
               ? [
                   {
                     property: 'article:published_time',
-                    content: publishedTime,
+                    content: publishedDateTime,
                   },
                 ]
               : []),
-            ...(modifiedTime
+            ...(modifiedDateTime
               ? [
                   {
                     property: 'article:modified_time',
-                    content: modifiedTime,
+                    content: modifiedDateTime,
                   },
                 ]
               : []),
@@ -127,7 +135,19 @@ export function seo({
       { name: 'twitter:image', content: socialImage },
       { name: 'twitter:image:alt', content: documentTitle },
     ],
-    links: [{ rel: 'canonical', href: canonical }],
+    links: [
+      { rel: 'canonical', href: canonical },
+      ...(markdownPath
+        ? [
+            {
+              rel: 'alternate',
+              type: 'text/markdown',
+              href: new URL(markdownPath, SITE.origin).href,
+              title: `${documentTitle} — Markdown`,
+            },
+          ]
+        : []),
+    ],
     scripts: schema
       ? [
           {
@@ -137,6 +157,19 @@ export function seo({
         ]
       : [],
   }
+}
+
+export function toIsoDateTime(date: string) {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return `${date}T00:00:00Z`
+  }
+
+  if (/(?:Z|[+-]\d{2}:\d{2})$/.test(date)) {
+    return date
+  }
+
+  const parsed = new Date(date)
+  return Number.isNaN(parsed.valueOf()) ? date : parsed.toISOString()
 }
 
 export function breadcrumb(items: Array<{ name: string; path?: string }>) {

--- a/tanstack/src/routeTree.gen.ts
+++ b/tanstack/src/routeTree.gen.ts
@@ -13,15 +13,18 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as R404RouteImport } from './routes/404'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as HiringRouteImport } from './routes/hiring'
+import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as PagefindRouteImport } from './routes/pagefind'
 import { Route as RssDotxmlRouteImport } from './routes/rss[.]xml'
 import { Route as Sitemap0DotxmlRouteImport } from './routes/sitemap-0[.]xml'
 import { Route as SitemapIndexDotxmlRouteImport } from './routes/sitemap-index[.]xml'
 import { Route as BlogIndexRouteImport } from './routes/blog.index'
 import { Route as BlogSlugRouteImport } from './routes/blog.$slug'
+import { Route as BlogChar123slugChar125DotmdRouteImport } from './routes/blog.{$slug}[.]md'
 import { Route as InternalComponentsRouteImport } from './routes/internal.components'
 import { Route as ProjectsIndexRouteImport } from './routes/projects.index'
 import { Route as ProjectsSlugRouteImport } from './routes/projects.$slug'
+import { Route as ProjectsChar123slugChar125DotmdRouteImport } from './routes/projects.{$slug}[.]md'
 import { Route as TagsIndexRouteImport } from './routes/tags.index'
 import { Route as TagsTagRouteImport } from './routes/tags.$tag'
 import { Route as TopicsIndexRouteImport } from './routes/topics.index'
@@ -45,6 +48,11 @@ const AboutRoute = AboutRouteImport.update({
 const HiringRoute = HiringRouteImport.update({
   id: '/hiring',
   path: '/hiring',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
+  id: '/llms.txt',
+  path: '/llms.txt',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PagefindRoute = PagefindRouteImport.update({
@@ -77,6 +85,12 @@ const BlogSlugRoute = BlogSlugRouteImport.update({
   path: '/blog/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BlogChar123slugChar125DotmdRoute =
+  BlogChar123slugChar125DotmdRouteImport.update({
+    id: '/blog/{$slug}.md',
+    path: '/blog/{$slug}.md',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const InternalComponentsRoute = InternalComponentsRouteImport.update({
   id: '/internal/components',
   path: '/internal/components',
@@ -92,6 +106,12 @@ const ProjectsSlugRoute = ProjectsSlugRouteImport.update({
   path: '/projects/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ProjectsChar123slugChar125DotmdRoute =
+  ProjectsChar123slugChar125DotmdRouteImport.update({
+    id: '/projects/{$slug}.md',
+    path: '/projects/{$slug}.md',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const TagsIndexRoute = TagsIndexRouteImport.update({
   id: '/tags/',
   path: '/tags/',
@@ -118,13 +138,16 @@ export interface FileRoutesByFullPath {
   '/404': typeof R404Route
   '/about': typeof AboutRoute
   '/hiring': typeof HiringRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/pagefind': typeof PagefindRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap-0.xml': typeof Sitemap0DotxmlRoute
   '/sitemap-index.xml': typeof SitemapIndexDotxmlRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/blog/{$slug}.md': typeof BlogChar123slugChar125DotmdRoute
   '/internal/components': typeof InternalComponentsRoute
   '/projects/$slug': typeof ProjectsSlugRoute
+  '/projects/{$slug}.md': typeof ProjectsChar123slugChar125DotmdRoute
   '/tags/$tag': typeof TagsTagRoute
   '/topics/$topic': typeof TopicsTopicRoute
   '/blog/': typeof BlogIndexRoute
@@ -137,13 +160,16 @@ export interface FileRoutesByTo {
   '/404': typeof R404Route
   '/about': typeof AboutRoute
   '/hiring': typeof HiringRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/pagefind': typeof PagefindRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap-0.xml': typeof Sitemap0DotxmlRoute
   '/sitemap-index.xml': typeof SitemapIndexDotxmlRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/blog/{$slug}.md': typeof BlogChar123slugChar125DotmdRoute
   '/internal/components': typeof InternalComponentsRoute
   '/projects/$slug': typeof ProjectsSlugRoute
+  '/projects/{$slug}.md': typeof ProjectsChar123slugChar125DotmdRoute
   '/tags/$tag': typeof TagsTagRoute
   '/topics/$topic': typeof TopicsTopicRoute
   '/blog': typeof BlogIndexRoute
@@ -157,13 +183,16 @@ export interface FileRoutesById {
   '/404': typeof R404Route
   '/about': typeof AboutRoute
   '/hiring': typeof HiringRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/pagefind': typeof PagefindRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap-0.xml': typeof Sitemap0DotxmlRoute
   '/sitemap-index.xml': typeof SitemapIndexDotxmlRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/blog/{$slug}.md': typeof BlogChar123slugChar125DotmdRoute
   '/internal/components': typeof InternalComponentsRoute
   '/projects/$slug': typeof ProjectsSlugRoute
+  '/projects/{$slug}.md': typeof ProjectsChar123slugChar125DotmdRoute
   '/tags/$tag': typeof TagsTagRoute
   '/topics/$topic': typeof TopicsTopicRoute
   '/blog/': typeof BlogIndexRoute
@@ -178,13 +207,16 @@ export interface FileRouteTypes {
     | '/404'
     | '/about'
     | '/hiring'
+    | '/llms.txt'
     | '/pagefind'
     | '/rss.xml'
     | '/sitemap-0.xml'
     | '/sitemap-index.xml'
     | '/blog/$slug'
+    | '/blog/{$slug}.md'
     | '/internal/components'
     | '/projects/$slug'
+    | '/projects/{$slug}.md'
     | '/tags/$tag'
     | '/topics/$topic'
     | '/blog/'
@@ -197,13 +229,16 @@ export interface FileRouteTypes {
     | '/404'
     | '/about'
     | '/hiring'
+    | '/llms.txt'
     | '/pagefind'
     | '/rss.xml'
     | '/sitemap-0.xml'
     | '/sitemap-index.xml'
     | '/blog/$slug'
+    | '/blog/{$slug}.md'
     | '/internal/components'
     | '/projects/$slug'
+    | '/projects/{$slug}.md'
     | '/tags/$tag'
     | '/topics/$topic'
     | '/blog'
@@ -216,13 +251,16 @@ export interface FileRouteTypes {
     | '/404'
     | '/about'
     | '/hiring'
+    | '/llms.txt'
     | '/pagefind'
     | '/rss.xml'
     | '/sitemap-0.xml'
     | '/sitemap-index.xml'
     | '/blog/$slug'
+    | '/blog/{$slug}.md'
     | '/internal/components'
     | '/projects/$slug'
+    | '/projects/{$slug}.md'
     | '/tags/$tag'
     | '/topics/$topic'
     | '/blog/'
@@ -236,13 +274,16 @@ export interface RootRouteChildren {
   R404Route: typeof R404Route
   AboutRoute: typeof AboutRoute
   HiringRoute: typeof HiringRoute
+  LlmsDottxtRoute: typeof LlmsDottxtRoute
   PagefindRoute: typeof PagefindRoute
   RssDotxmlRoute: typeof RssDotxmlRoute
   Sitemap0DotxmlRoute: typeof Sitemap0DotxmlRoute
   SitemapIndexDotxmlRoute: typeof SitemapIndexDotxmlRoute
   BlogSlugRoute: typeof BlogSlugRoute
+  BlogChar123slugChar125DotmdRoute: typeof BlogChar123slugChar125DotmdRoute
   InternalComponentsRoute: typeof InternalComponentsRoute
   ProjectsSlugRoute: typeof ProjectsSlugRoute
+  ProjectsChar123slugChar125DotmdRoute: typeof ProjectsChar123slugChar125DotmdRoute
   TagsTagRoute: typeof TagsTagRoute
   TopicsTopicRoute: typeof TopicsTopicRoute
   BlogIndexRoute: typeof BlogIndexRoute
@@ -279,6 +320,13 @@ declare module '@tanstack/react-router' {
       path: '/hiring'
       fullPath: '/hiring'
       preLoaderRoute: typeof HiringRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/llms.txt': {
+      id: '/llms.txt'
+      path: '/llms.txt'
+      fullPath: '/llms.txt'
+      preLoaderRoute: typeof LlmsDottxtRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/pagefind': {
@@ -323,6 +371,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/blog/{$slug}.md': {
+      id: '/blog/{$slug}.md'
+      path: '/blog/{$slug}.md'
+      fullPath: '/blog/{$slug}.md'
+      preLoaderRoute: typeof BlogChar123slugChar125DotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/internal/components': {
       id: '/internal/components'
       path: '/internal/components'
@@ -342,6 +397,13 @@ declare module '@tanstack/react-router' {
       path: '/projects/$slug'
       fullPath: '/projects/$slug'
       preLoaderRoute: typeof ProjectsSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/projects/{$slug}.md': {
+      id: '/projects/{$slug}.md'
+      path: '/projects/{$slug}.md'
+      fullPath: '/projects/{$slug}.md'
+      preLoaderRoute: typeof ProjectsChar123slugChar125DotmdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/tags/': {
@@ -380,13 +442,16 @@ const rootRouteChildren: RootRouteChildren = {
   R404Route: R404Route,
   AboutRoute: AboutRoute,
   HiringRoute: HiringRoute,
+  LlmsDottxtRoute: LlmsDottxtRoute,
   PagefindRoute: PagefindRoute,
   RssDotxmlRoute: RssDotxmlRoute,
   Sitemap0DotxmlRoute: Sitemap0DotxmlRoute,
   SitemapIndexDotxmlRoute: SitemapIndexDotxmlRoute,
   BlogSlugRoute: BlogSlugRoute,
+  BlogChar123slugChar125DotmdRoute: BlogChar123slugChar125DotmdRoute,
   InternalComponentsRoute: InternalComponentsRoute,
   ProjectsSlugRoute: ProjectsSlugRoute,
+  ProjectsChar123slugChar125DotmdRoute: ProjectsChar123slugChar125DotmdRoute,
   TagsTagRoute: TagsTagRoute,
   TopicsTopicRoute: TopicsTopicRoute,
   BlogIndexRoute: BlogIndexRoute,

--- a/tanstack/src/routes/about.tsx
+++ b/tanstack/src/routes/about.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute('/about')({
             sameAs: [
               'https://github.com/spa5k',
               'https://linkedin.com/in/kamrantahir2',
-              'http://kamran.sh/',
+              'https://kamran.sh/',
             ],
             email: SITE.email,
             knowsLanguage: ['en'],
@@ -90,7 +90,7 @@ function About() {
           </p>
           <div className="profile-actions">
             <a href={`mailto:${SITE.email}`}>Email</a>
-            <a href="http://kamran.sh/" target="_blank" rel="noreferrer">
+            <a href="https://kamran.sh/" target="_blank" rel="noreferrer">
               Resume
             </a>
             <a

--- a/tanstack/src/routes/blog.$slug.tsx
+++ b/tanstack/src/routes/blog.$slug.tsx
@@ -10,12 +10,13 @@ import {
   formatDate,
   getPost,
   getRelatedPosts,
+  isNavigableTag,
   legacyPostRedirects,
   posts,
 } from '@/lib/content'
 import { Giscus } from '@/components/Giscus'
 import CodeWindow from '@/components/mdx/CodeWindow'
-import { SITE, breadcrumb, seo } from '@/lib/site'
+import { SITE, breadcrumb, seo, toIsoDateTime } from '@/lib/site'
 
 export const Route = createFileRoute('/blog/$slug')({
   beforeLoad: ({ params }) => {
@@ -46,6 +47,7 @@ export const Route = createFileRoute('/blog/$slug')({
       title: loaderData.title,
       description: loaderData.description,
       path: `/blog/${loaderData.slug}`,
+      markdownPath: `/blog/${loaderData.slug}.md`,
       image: loaderData.ogImage,
       type: 'article',
       publishedTime: loaderData.date,
@@ -77,8 +79,8 @@ export const Route = createFileRoute('/blog/$slug')({
                 url: `${SITE.origin}/images/saybackend.png`,
               },
             },
-            datePublished: loaderData.date,
-            dateModified: loaderData.updated ?? loaderData.date,
+            datePublished: toIsoDateTime(loaderData.date),
+            dateModified: toIsoDateTime(loaderData.updated ?? loaderData.date),
             description: loaderData.description,
             mainEntityOfPage: { '@type': 'WebPage', '@id': url },
             inLanguage: 'en-US',
@@ -134,13 +136,24 @@ function PostPage() {
           <span>By Kamran Tahir</span>
           <time dateTime={post.date}>{formatDate(post.date)}</time>
           <span>{post.readingMinutes} min read</span>
+          <a
+            href={`/blog/${post.slug}.md`}
+            rel="alternate"
+            type="text/markdown"
+          >
+            Markdown
+          </a>
         </div>
         <div className="post-tags">
-          {(post.tags ?? []).slice(0, 6).map((tag) => (
-            <Link key={tag} to="/tags/$tag" params={{ tag }}>
-              {tag}
-            </Link>
-          ))}
+          {(post.tags ?? []).slice(0, 6).map((tag) =>
+            isNavigableTag(tag) ? (
+              <Link key={tag} to="/tags/$tag" params={{ tag }}>
+                {tag}
+              </Link>
+            ) : (
+              <span key={tag}>{tag}</span>
+            ),
+          )}
         </div>
       </header>
       {post.wip ? (

--- a/tanstack/src/routes/blog.{$slug}[.]md.ts
+++ b/tanstack/src/routes/blog.{$slug}[.]md.ts
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { legacyPostRedirects } from '@/lib/content'
+import { getBlogMarkdown, markdownResponse } from '@/lib/markdown.server'
+
+export const Route = createFileRoute('/blog/{$slug}.md')({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const destination = legacyPostRedirects[params.slug]
+        if (destination) {
+          return Response.redirect(
+            new URL(`${destination}.md`, request.url).href,
+            301,
+          )
+        }
+
+        return markdownResponse(getBlogMarkdown(params.slug))
+      },
+    },
+  },
+})

--- a/tanstack/src/routes/hiring.tsx
+++ b/tanstack/src/routes/hiring.tsx
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/hiring')({
             sameAs: [
               'https://github.com/spa5k',
               'https://linkedin.com/in/kamrantahir2',
-              'http://kamran.sh/',
+              'https://kamran.sh/',
             ],
             knowsAbout: [
               'Backend Development',
@@ -101,7 +101,7 @@ function Hiring() {
           </p>
           <div className="profile-actions">
             <a href={`mailto:${SITE.email}`}>Start a conversation</a>
-            <a href="http://kamran.sh/" target="_blank" rel="noreferrer">
+            <a href="https://kamran.sh/" target="_blank" rel="noreferrer">
               View resume
             </a>
             <Link to="/projects">Projects</Link>

--- a/tanstack/src/routes/index.tsx
+++ b/tanstack/src/routes/index.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute('/')({
             url: `${SITE.origin}/`,
             name: SITE.title,
             description:
-              'A engineering blog dedicated to backend systems, DevOps, and structural data patterns',
+              'An engineering blog dedicated to backend systems, DevOps, and structural data patterns',
             publisher: { '@id': `${SITE.origin}/#organization` },
             potentialAction: {
               '@type': 'SearchAction',
@@ -38,7 +38,11 @@ export const Route = createFileRoute('/')({
               '@type': 'ImageObject',
               url: `${SITE.origin}/favicon.ico`,
             },
-            sameAs: ['https://github.com/spa5k'],
+            sameAs: [
+              'https://github.com/spa5k',
+              'https://linkedin.com/in/kamrantahir2',
+              'https://kamran.sh/',
+            ],
             contactPoint: {
               '@type': 'ContactPoint',
               email: SITE.email,
@@ -120,6 +124,8 @@ function Home() {
             </div>
             <img
               src="/images/editorial-still-life-640.webp"
+              srcSet="/images/editorial-still-life-320.webp 320w, /images/editorial-still-life-640.webp 640w"
+              sizes="(max-width: 1050px) 0px, 320px"
               alt="Etched illustration of technical books, coffee, and an open notebook"
               className="featured-illustration"
               width={640}

--- a/tanstack/src/routes/llms[.]txt.ts
+++ b/tanstack/src/routes/llms[.]txt.ts
@@ -1,0 +1,54 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { posts, projects } from '@/lib/content'
+import { SITE } from '@/lib/site'
+
+export const Route = createFileRoute('/llms.txt')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const text = `# ${SITE.title}
+
+> ${SITE.description}
+
+SayBackend is Kamran Tahir's engineering publication about backend systems, DevOps, databases, infrastructure, and practical AI tooling.
+
+## Main pages
+
+- [Home](${SITE.origin}/)
+- [Blog archive](${SITE.origin}/blog/)
+- [Topic guides](${SITE.origin}/topics/)
+- [Projects](${SITE.origin}/projects/)
+- [About the author](${SITE.origin}/about/)
+- [RSS feed](${SITE.origin}/rss.xml)
+
+## Articles
+
+${posts
+  .map(
+    (post) =>
+      `- [${post.title}](${SITE.origin}${post.href}/): ${post.description}\n  - [Markdown](${SITE.origin}${post.href}.md)`,
+  )
+  .join('\n')}
+
+## Projects
+
+${projects
+  .map(
+    (project) =>
+      `- [${project.title}](${SITE.origin}${project.href}/): ${project.description}\n  - [Markdown](${SITE.origin}${project.href}.md)`,
+  )
+  .join('\n')}
+`
+
+        return new Response(text, {
+          headers: {
+            'Cache-Control':
+              'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800',
+            'Content-Type': 'text/plain; charset=utf-8',
+          },
+        })
+      },
+    },
+  },
+})

--- a/tanstack/src/routes/projects.$slug.tsx
+++ b/tanstack/src/routes/projects.$slug.tsx
@@ -21,6 +21,7 @@ export const Route = createFileRoute('/projects/$slug')({
           title: loaderData.title,
           description: loaderData.description,
           path: `/projects/${loaderData.slug}`,
+          markdownPath: `/projects/${loaderData.slug}.md`,
         })
       : {},
   component: ProjectPage,
@@ -39,7 +40,16 @@ function ProjectPage() {
         </Link>
         <h1>{project.title}</h1>
         <p>{project.description}</p>
-        <time dateTime={project.date}>{formatDate(project.date)}</time>
+        <div className="post-byline">
+          <time dateTime={project.date}>{formatDate(project.date)}</time>
+          <a
+            href={`/projects/${project.slug}.md`}
+            rel="alternate"
+            type="text/markdown"
+          >
+            Markdown
+          </a>
+        </div>
       </header>
       <div className="post-body page-frame">
         <Suspense fallback={<p>Loading project…</p>}>

--- a/tanstack/src/routes/projects.{$slug}[.]md.ts
+++ b/tanstack/src/routes/projects.{$slug}[.]md.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { getProjectMarkdown, markdownResponse } from '@/lib/markdown.server'
+
+export const Route = createFileRoute('/projects/{$slug}.md')({
+  server: {
+    handlers: {
+      GET: async ({ params }) =>
+        markdownResponse(getProjectMarkdown(params.slug)),
+    },
+  },
+})

--- a/tanstack/src/routes/tags.$tag.tsx
+++ b/tanstack/src/routes/tags.$tag.tsx
@@ -1,10 +1,11 @@
 import { Link, createFileRoute, notFound } from '@tanstack/react-router'
 
-import { formatDate, posts } from '@/lib/content'
+import { formatDate, isNavigableTag, posts } from '@/lib/content'
 import { seo } from '@/lib/site'
 
 export const Route = createFileRoute('/tags/$tag')({
   loader: ({ params }) => {
+    if (!isNavigableTag(params.tag)) throw notFound()
     const tagPosts = posts.filter((post) => post.tags?.includes(params.tag))
     if (!tagPosts.length) throw notFound()
     return {

--- a/tanstack/src/routes/tags.index.tsx
+++ b/tanstack/src/routes/tags.index.tsx
@@ -1,6 +1,6 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
 
-import { posts } from '@/lib/content'
+import { navigableTags } from '@/lib/content'
 import { seo } from '@/lib/site'
 
 export const Route = createFileRoute('/tags/')({
@@ -15,21 +15,15 @@ export const Route = createFileRoute('/tags/')({
 })
 
 function Tags() {
-  const counts = new Map<string, number>()
-  posts.forEach((post) =>
-    post.tags?.forEach((tag) => counts.set(tag, (counts.get(tag) ?? 0) + 1)),
-  )
-  const tags = [...counts.entries()].sort((a, b) => b[1] - a[1])
-
   return (
     <section className="page-frame collection-page">
       <header className="page-heading">
         <p className="eyebrow">Index</p>
         <h1>Tags</h1>
-        <p>Every label used across the archive.</p>
+        <p>Recurring labels used across the archive.</p>
       </header>
       <div className="tag-cloud">
-        {tags.map(([tag, count]) => (
+        {navigableTags.map(([tag, count]) => (
           <Link key={tag} to="/tags/$tag" params={{ tag }}>
             {tag} <span>{count}</span>
           </Link>

--- a/tanstack/src/styles.css
+++ b/tanstack/src/styles.css
@@ -725,7 +725,8 @@ img {
   margin-top: 18px;
 }
 
-.post-tags a {
+.post-tags a,
+.post-tags > span {
   border: 1px solid var(--rule);
   padding: 5px 8px;
 }

--- a/tanstack/vite.config.ts
+++ b/tanstack/vite.config.ts
@@ -19,6 +19,7 @@ import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
 import svgr from 'vite-plugin-svgr'
 
 const frontmatterModulePrefix = '\0saybackend-frontmatter:'
+const contentSourceModulePrefix = '\0saybackend-content-source:'
 
 const codeWindowTransformer: ShikiTransformer = {
   name: 'saybackend-code-window',
@@ -110,15 +111,26 @@ function frontmatterOnly(): Plugin {
     enforce: 'pre' as const,
     async resolveId(id: string, importer: string | undefined) {
       const [source, query = ''] = id.split('?', 2)
-      if (!new URLSearchParams(query).has('frontmatter-only')) return
+      const params = new URLSearchParams(query)
+      const prefix = params.has('frontmatter-only')
+        ? frontmatterModulePrefix
+        : params.has('content-source-only')
+          ? contentSourceModulePrefix
+          : undefined
+      if (!prefix) return
 
       const resolved = await this.resolve(source, importer, { skipSelf: true })
       if (!resolved) return
-      return `${frontmatterModulePrefix}${resolved.id}`
+      return `${prefix}${resolved.id}`
     },
     async load(id: string) {
-      if (!id.startsWith(frontmatterModulePrefix)) return
+      if (id.startsWith(contentSourceModulePrefix)) {
+        const file = id.slice(contentSourceModulePrefix.length)
+        const source = await readFile(file, 'utf8')
+        return `export default ${JSON.stringify(source)}`
+      }
 
+      if (!id.startsWith(frontmatterModulePrefix)) return
       const file = id.slice(frontmatterModulePrefix.length)
       const source = await readFile(file, 'utf8')
       const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
@@ -178,6 +190,7 @@ const config = defineConfig({
       pages: [
         { path: '/404' },
         { path: '/rss.xml' },
+        { path: '/llms.txt' },
         { path: '/sitemap-index.xml' },
         { path: '/sitemap-0.xml' },
       ],
@@ -185,6 +198,7 @@ const config = defineConfig({
         enabled: true,
         crawlLinks: true,
         autoStaticPathsDiscovery: true,
+        filter: ({ path }) => !path.endsWith('.md'),
         failOnError: true,
       },
     }),


### PR DESCRIPTION
## Summary

- Add SEO and crawler-friendly routes, including `robots.txt` and `llms.txt`
- Improve Markdown rendering and content metadata across blog and project pages
- Update site shell, route validation, static build finalization, and page styling
- Refresh route generation and configuration for the new static output

## Testing

- Not run (not requested)